### PR TITLE
Added the ability to resolve device ids like "#1" to actual device URIs.

### DIFF
--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -78,6 +78,8 @@ private:
 
   void readConfigFromParameterServer();
 
+  // resolves non-URI device IDs to URIs, e.g. '#1' is resolved to the URI of the first device
+  std::string resolveDeviceURI(const std::string& device_id) throw(OpenNI2Exception);
   void initDevice();
 
   void advertiseROSTopics();


### PR DESCRIPTION
Resolves ros-drivers/openni2_camera#2
