### PR TITLE
disable mirroring of all streams at startup

### DIFF
--- a/include/openni2_camera/openni2_device.h
+++ b/include/openni2_camera/openni2_device.h
@@ -129,7 +129,7 @@ public:
   bool getAutoExposure() const;
   bool getAutoWhiteBalance() const;
 
-  bool setUseDeviceTimer(bool enable);
+  void setUseDeviceTimer(bool enable);
 
 protected:
   void shutdown();

--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -247,6 +247,7 @@ void OpenNI2Device::startIRStream()
 
   if (stream)
   {
+    stream->setMirroringEnabled(false);
     stream->start();
     stream->addNewFrameListener(ir_frame_listener.get());
     ir_video_started_ = true;
@@ -260,6 +261,7 @@ void OpenNI2Device::startColorStream()
 
   if (stream)
   {
+    stream->setMirroringEnabled(false);
     stream->start();
     stream->addNewFrameListener(color_frame_listener.get());
     color_video_started_ = true;
@@ -271,6 +273,7 @@ void OpenNI2Device::startDepthStream()
 
   if (stream)
   {
+    stream->setMirroringEnabled(false);
     stream->start();
     stream->addNewFrameListener(depth_frame_listener.get());
     depth_video_started_ = true;
@@ -581,7 +584,7 @@ bool OpenNI2Device::getAutoWhiteBalance() const
   return ret;
 }
 
-bool OpenNI2Device::setUseDeviceTimer(bool enable)
+void OpenNI2Device::setUseDeviceTimer(bool enable)
 {
   if (ir_frame_listener)
     ir_frame_listener->setUseDeviceTimer(enable);


### PR DESCRIPTION
The new openni2 driver mirrors all streams by default. This PR disables mirroring for each video stream on startup.

It also contains a small fix for a setter function's return value.
