### PR TITLE
enable selection of device based on the bus id using @<bus>

### DIFF
--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -609,7 +609,7 @@ std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id) throw(
   boost::shared_ptr<std::vector<std::string> > available_device_URIs = 
     device_manager_->getConnectedDeviceURIs();
 
-  // look for '#<number>' format
+  // look for '#<number>' format (specifies device id)
   if (device_id_.size() > 1 && device_id_[0] == '#')
   {
     std::istringstream device_number_str(device_id_.substr(1));
@@ -625,6 +625,18 @@ std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id) throw(
     else
     {
       return available_device_URIs->at(device_index);
+    }
+  }
+  // look for '@<number>' format (specifies bus id)
+  else if (device_id_.size() > 1 && device_id_[0] == '@')
+  {
+    for (size_t i = 0; i < available_device_URIs->size(); ++i)
+    {
+      std::string s = (*available_device_URIs)[i];
+      if (s.find(device_id_) != std::string::npos)
+      {
+        return s;
+      }
     }
   }
   // everything else is treated as device_URI directly


### PR DESCRIPTION
This was a key feature of the openni_camera drivers which allowed you to have multiple cameras, each on their own bus, and always get the one you wanted.

This is compatible with openni_camera, with the form "bus@index" where bus is the USB bus id (typically starts at 1) and index is the device on that bus (starts at 1, but 0 basically says "any device" and returns the first one found by the manager).

I've tested this with Asus Xtion Pro Live, 1.082 and 1.09 sensors in several configurations.
