### PR TITLE
Fix CMake error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(include
                     ${PC_OPENNI2_INCLUDE_DIRS}
                     )
 
-message (${PC_OPENNI2_LIBRARY_DIRS})
+message ("${PC_OPENNI2_LIBRARY_DIRS}")
 link_directories(${PC_OPENNI2_LIBRARY_DIRS})
 
 add_library(openni2_wrapper


### PR DESCRIPTION
CMake Error at CMakeLists.txt:26 (message):
  message called with incorrect number of arguments
