### PR TITLE
Updated cmakelists for OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_trans
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 find_package(PkgConfig)
-pkg_check_modules(PC_OPENNI2 REQUIRED libopenni2)
+
+pkg_check_modules(PC_OPENNI2 libopenni2)
+if (NOT PC_OPENNI2_FOUND)
+  pkg_check_modules(PC_OPENNI2 REQUIRED openni2)
+endif()
 
 generate_dynamic_reconfigure_options(cfg/OpenNI2.cfg)
 


### PR DESCRIPTION
Previously this wouldn't work on OSX. The OpenNI2 library is just called 'openni2' (not 'libopenni2'). This now first checks for 'libopenni2' and if it doesn't find it then it checks for 'openni2'.
