### PR TITLE
Depth only sensors

### DIFF
--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -135,7 +135,7 @@ bool OpenNI2Device::isValid() const
 float OpenNI2Device::getIRFocalLength(int output_y_resolution) const
 {
   float focal_length = 0.0f;
-  boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
+  boost::shared_ptr<openni::VideoStream> stream = getIRVideoStream();
 
   if (stream)
   {
@@ -161,7 +161,7 @@ float OpenNI2Device::getColorFocalLength(int output_y_resolution) const
 float OpenNI2Device::getDepthFocalLength(int output_y_resolution) const
 {
   float focal_length = 0.0f;
-  boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
+  boost::shared_ptr<openni::VideoStream> stream = getDepthVideoStream();
 
   if (stream)
   {


### PR DESCRIPTION
Fixed a annoying bug that prevents depth only sensors from properly calculating the point cloud due to incorrect focal length.

It was very hard to trace, but I noticed that the focal length was zero when passed to depth_image_proc/point_cloud_xyz nodelet 

I also had to modify the depth.launch.xml , and use in the depth_image_proc/point_cloud_xyz nodelet  image_raw instead of image_rect_raw (was not being generated due to the lack of calibration file)

I tested this change with:
- Xtion Pro Live
- Xtion Pro
- Occipital Structure sensor

and it worked with all of them !
