### PR TITLE
add usb_reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,9 @@ add_executable(openni2_camera_node
 target_link_libraries(openni2_camera_node openni2_driver_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES} )
 add_dependencies(openni2_camera_node ${PROJECT_NAME}_gencfg)
 
-install(TARGETS openni2_wrapper openni2_camera_nodelet openni2_camera_node openni2_driver_lib
+add_executable(usb_reset src/usb_reset.c)
+
+install(TARGETS openni2_wrapper openni2_camera_nodelet openni2_camera_node openni2_driver_lib usb_reset
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/src/usb_reset.c
+++ b/src/usb_reset.c
@@ -1,0 +1,71 @@
+/* usbreset -- send a USB port reset to a USB device */
+
+/*
+ * Copyright (c) 2014, JSK Robotics Lab, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *      Author: Ryohei Ueda (ueda@jsk.t.u-tokyo.ac.jp)
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+
+#include <linux/usbdevice_fs.h>
+
+
+int main(int argc, char **argv)
+{
+  const char *filename;
+  int fd;
+  int rc;
+
+  if (argc != 2) {
+    fprintf(stderr, "Usage: usbreset device-filename\n");
+    return 1;
+  }
+  filename = argv[1];
+
+  fd = open(filename, O_WRONLY);
+  if (fd < 0) {
+    perror("Error opening output file");
+    return 1;
+  }
+
+  printf("Resetting USB device %s\n", filename);
+  rc = ioctl(fd, USBDEVFS_RESET, 0);
+  if (rc < 0) {
+    perror("Error in ioctl");
+    return 1;
+  }
+  printf("Reset successful\n");
+
+  close(fd);
+  return 0;
+}


### PR DESCRIPTION
Hi

Sometimes, openni2 driver is not able to open or connect to device and we have to physically re-connect the USB cable to reset usb status, This program (usb_reset) is do similar effect with software.

if you know the usb device path using `lsusb` command, then you can try

```
rosrun openni2_camera usb_reset /dev/bus/usb/002/017
```

Cc: @garaemon
