### PR TITLE
Explicit serial query in OpenNI2Driver::resolveDeviceURI instead of one-time query in OpenNI2DeviceListener::onDeviceConnected & new binary to list devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ link_directories(${PC_OPENNI2_LIBRARY_DIRS})
 add_library(openni2_wrapper
    src/openni2_convert.cpp
    src/openni2_device.cpp 
+   src/openni2_device_info.cpp 
    src/openni2_timer_filter.cpp 
    src/openni2_frame_listener.cpp
    src/openni2_device_manager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(openni2_wrapper
    src/openni2_exception.cpp
    src/openni2_video_mode.cpp
 )
-target_link_libraries(openni2_wrapper openni2_wrapper ${catkin_LIBRARIES} ${PC_OPENNI2_LIBRARIES} ${Boost_LIBRARIES} )
+target_link_libraries(openni2_wrapper ${catkin_LIBRARIES} ${PC_OPENNI2_LIBRARIES} ${Boost_LIBRARIES} )
 
 add_executable(test_wrapper test/test_wrapper.cpp )
 target_link_libraries(test_wrapper openni2_wrapper ${Boost_LIBRARIES})
@@ -62,9 +62,14 @@ add_executable(openni2_camera_node
 target_link_libraries(openni2_camera_node openni2_driver_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES} )
 add_dependencies(openni2_camera_node ${PROJECT_NAME}_gencfg)
 
+add_executable(list_devices
+   src/list_devices.cpp
+)
+target_link_libraries(list_devices openni2_wrapper)
+
 add_executable(usb_reset src/usb_reset.c)
 
-install(TARGETS openni2_wrapper openni2_camera_nodelet openni2_camera_node openni2_driver_lib usb_reset
+install(TARGETS openni2_wrapper openni2_camera_nodelet openni2_camera_node list_devices openni2_driver_lib usb_reset
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/include/openni2_camera/openni2_convert.h
+++ b/include/openni2_camera/openni2_convert.h
@@ -43,7 +43,7 @@
 namespace openni2_wrapper
 {
 
-const OpenNI2DeviceInfo openni2_convert(const openni::DeviceInfo* pInfo, std::string serial = "");
+const OpenNI2DeviceInfo openni2_convert(const openni::DeviceInfo* pInfo);
 
 const OpenNI2VideoMode openni2_convert(const openni::VideoMode& input);
 const openni::VideoMode openni2_convert(const OpenNI2VideoMode& input);

--- a/include/openni2_camera/openni2_device_info.h
+++ b/include/openni2_camera/openni2_device_info.h
@@ -44,7 +44,6 @@ struct OpenNI2DeviceInfo
   std::string uri_;
   std::string vendor_;
   std::string name_;
-  std::string serial_;
   uint16_t vendor_id_;
   uint16_t product_id_;
 };

--- a/include/openni2_camera/openni2_device_manager.h
+++ b/include/openni2_camera/openni2_device_manager.h
@@ -61,6 +61,8 @@ public:
   boost::shared_ptr<OpenNI2Device> getAnyDevice();
   boost::shared_ptr<OpenNI2Device> getDevice(const std::string& device_URI);
 
+  std::string getSerial(const std::string& device_URI) const;
+
 protected:
   boost::shared_ptr<OpenNI2DeviceListener> device_listener_;
 

--- a/src/list_devices.cpp
+++ b/src/list_devices.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014, Savioke, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *      Author: Stephan Wirth (wirth@savioke.com)
+ */
+
+/**
+ * Small executable that creates a device manager to print the information of all devices including their
+ * serial number.
+ */
+
+#include <iostream>
+#include "openni2_camera/openni2_device_manager.h"
+#include "openni2_camera/openni2_exception.h"
+
+using openni2_wrapper::OpenNI2DeviceManager;
+using openni2_wrapper::OpenNI2DeviceInfo;
+using openni2_wrapper::OpenNI2Exception;
+
+int main(int arc, char** argv)
+{
+  openni2_wrapper::OpenNI2DeviceManager manager;
+  boost::shared_ptr<std::vector<openni2_wrapper::OpenNI2DeviceInfo> > device_infos = manager.getConnectedDeviceInfos();
+  std::cout << "Found " << device_infos->size() << " devices:" << std::endl << std::endl;
+  for (size_t i = 0; i < device_infos->size(); ++i)
+  {
+    std::cout << "Device #" << i << ":" << std::endl;
+    std::cout << device_infos->at(i) << std::endl;
+    try {
+      std::string serial = manager.getSerial(device_infos->at(i).uri_);
+      std::cout << "Serial number: " << serial << std::endl;
+    }
+    catch (const OpenNI2Exception& exception)
+    {
+      std::cerr << "Could not retrieve serial number: " << exception.what() << std::endl;
+    }
+  }
+  return 0;
+}
+

--- a/src/openni2_convert.cpp
+++ b/src/openni2_convert.cpp
@@ -39,7 +39,7 @@
 namespace openni2_wrapper
 {
 
-const OpenNI2DeviceInfo openni2_convert(const openni::DeviceInfo* pInfo, const std::string serial)
+const OpenNI2DeviceInfo openni2_convert(const openni::DeviceInfo* pInfo)
 {
   if (!pInfo)
     THROW_OPENNI_EXCEPTION("openni2_convert called with zero pointer\n");
@@ -51,7 +51,6 @@ const OpenNI2DeviceInfo openni2_convert(const openni::DeviceInfo* pInfo, const s
   output.vendor_     = pInfo->getVendor();
   output.product_id_ = pInfo->getUsbProductId();
   output.vendor_id_  = pInfo->getUsbVendorId();
-  output.serial_     = serial;
 
   return output;
 }

--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -71,7 +71,7 @@ OpenNI2Device::OpenNI2Device(const std::string& device_URI) throw (OpenNI2Except
   }
 
   if (rc != openni::STATUS_OK)
-    THROW_OPENNI_EXCEPTION("Initialize failed\n%s\n", openni::OpenNI::getExtendedError());
+    THROW_OPENNI_EXCEPTION("Device open failed\n%s\n", openni::OpenNI::getExtendedError());
 
   device_info_ = boost::make_shared<openni::DeviceInfo>();
   *device_info_ = openni_device_->getDeviceInfo();

--- a/src/openni2_device_info.cpp
+++ b/src/openni2_device_info.cpp
@@ -40,7 +40,6 @@ std::ostream& operator << (std::ostream& stream, const OpenNI2DeviceInfo& device
                                            ", Name: " << device_info.name_ <<
                                            ", Vendor ID: " << device_info.vendor_id_ <<
                                            ", Product ID: " << device_info.product_id_ <<
-                                           ", Serial number: " << device_info.serial_ <<
                                              ")" << std::endl;
   return stream;
 }

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -674,14 +674,18 @@ std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id) throw(
   else
   {
     // check if the device id given matches a serial number of a connected device
-    boost::shared_ptr<std::vector<OpenNI2DeviceInfo> > dev_infos =
-      device_manager_->getConnectedDeviceInfos();
-
-    for(std::vector<OpenNI2DeviceInfo>::iterator it = dev_infos->begin();
-        it != dev_infos->end(); ++it)
+    for(std::vector<std::string>::const_iterator it = available_device_URIs->begin();
+        it != available_device_URIs->end(); ++it)
     {
-      if (device_id.size()>0 && device_id == it->serial_)
-        return it->uri_;
+      try {
+        std::string serial = device_manager_->getSerial(*it);
+        if (serial.size() > 0 && device_id == serial)
+          return *it;
+      }
+      catch (const OpenNI2Exception& exception)
+      {
+        ROS_WARN("Could not query serial number of device \"%s\":", exception.what());
+      }
     }
 
     // everything else is treated as device_URI directly


### PR DESCRIPTION
 2e79f55 fixes #24. It changes the way serial numbers are handled. Instead of trying only once to retrieve the serial number when a device gets connected, the driver will repeat to try to read serial numbers from connected devices as long as no permanent connection has been established.

The device manager will only know vendor id, product id etc. (things you can see with `lsusb`, too) on startup and the serial number has to be requested explicitly as that requires opening the device.

2290783 adds a binary for convenience that prints out all information about connected devices and their serial number (if the devices could be opened).
