### PR TITLE
Improve device id lookup

### DIFF
--- a/src/openni2_device_info.cpp
+++ b/src/openni2_device_info.cpp
@@ -38,8 +38,8 @@ namespace openni2_wrapper
 std::ostream& operator << (std::ostream& stream, const OpenNI2DeviceInfo& device_info) {
   stream << "Uri: " << device_info.uri_ << " (Vendor: " << device_info.vendor_ <<
                                            ", Name: " << device_info.name_ <<
-                                           ", Vendor ID: " << device_info.vendor_id_ <<
-                                           ", Product ID: " << device_info.product_id_ <<
+                                           ", Vendor ID: " << std::hex << device_info.vendor_id_ <<
+                                           ", Product ID: " << std::hex << device_info.product_id_ <<
                                              ")" << std::endl;
   return stream;
 }


### PR DESCRIPTION
Two small improvements:
- print vendor and product id as hex value on `ostr << device_info`, just as `lsusb` does
- try to match device_id with available device URIs, even if only a (unique) part of the device URI is given as device_id

I also cleaned up the use of the member `device_id_` in `resolveDeviceURI` to use the given device_id parameter instead.

By the way, the `@` notation is quite confusing, as e.g. this device: `Bus 001 Device 006: ID 1d27:0609 ASUS` has to be specified as `1@1` (first openni device on bus 1) instead of `6@1`.
