### PR TITLE
added get_serial service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(openni2_camera)
 
-find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport  nodelet sensor_msgs roscpp)
+find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport  nodelet sensor_msgs roscpp message_generation)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -13,11 +13,14 @@ if (NOT PC_OPENNI2_FOUND)
 endif()
 
 generate_dynamic_reconfigure_options(cfg/OpenNI2.cfg)
+add_service_files(FILES
+  GetSerial.srv)
+generate_messages()
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES openni2_wrapper
-  CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp
+  CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
   DEPENDS libopenni2
 )
 
@@ -60,7 +63,7 @@ add_executable(openni2_camera_node
    ros/openni2_camera_node.cpp
 )
 target_link_libraries(openni2_camera_node openni2_driver_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES} )
-add_dependencies(openni2_camera_node ${PROJECT_NAME}_gencfg)
+add_dependencies(openni2_camera_node ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(list_devices
    src/list_devices.cpp

--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -51,6 +51,7 @@
 #include "openni2_camera/openni2_device_manager.h"
 #include "openni2_camera/openni2_device.h"
 #include "openni2_camera/openni2_video_mode.h"
+#include "openni2_camera/GetSerial.h"
 
 #include <ros/ros.h>
 
@@ -88,6 +89,8 @@ private:
   void depthConnectCb();
   void irConnectCb();
 
+  bool getSerialCb(openni2_camera::GetSerialRequest& req, openni2_camera::GetSerialResponse& res);
+
   void configCb(Config &config, uint32_t level);
 
   void applyConfigToOpenNIDevice();
@@ -108,6 +111,9 @@ private:
   boost::shared_ptr<OpenNI2Device> device_;
 
   std::string device_id_;
+
+  /** \brief get_serial server*/
+  ros::ServiceServer get_serial_server;
 
   /** \brief reconfigure server*/
   boost::shared_ptr<ReconfigureServer> reconfigure_server_;

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>libopenni2-dev</run_depend>
   <run_depend>camera_info_manager</run_depend>
@@ -27,6 +28,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/openni2_nodelets.xml"/>

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -139,6 +139,13 @@ void OpenNI2Driver::advertiseROSTopics()
   color_info_manager_ = boost::make_shared<camera_info_manager::CameraInfoManager>(color_nh, color_name, color_info_url_);
   ir_info_manager_  = boost::make_shared<camera_info_manager::CameraInfoManager>(ir_nh,  ir_name,  ir_info_url_);
 
+  get_serial_server = nh_.advertiseService("get_serial", &OpenNI2Driver::getSerialCb,this);
+
+}
+
+bool OpenNI2Driver::getSerialCb(openni2_camera::GetSerialRequest& req, openni2_camera::GetSerialResponse& res) {
+  res.serial = device_manager_->getSerial(device_->getUri());
+  return true;
 }
 
 void OpenNI2Driver::configCb(Config &config, uint32_t level)

--- a/srv/GetSerial.srv
+++ b/srv/GetSerial.srv
@@ -1,0 +1,2 @@
+---
+string serial


### PR DESCRIPTION
There is currently no way to get the serial number of the currently used device from the drive. This PR adds a service to get this service.

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
