### PR TITLE
Openni2 driver handles oni files

### DIFF
--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -679,6 +679,11 @@ std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id) throw(
 
     THROW_OPENNI_EXCEPTION("Device not found %s", device_id.c_str());
   }
+
+  // check if device_id is a oni file
+  else if( device_id.size() - device_id.rfind(".oni") == 4 ) {
+	return device_id;
+  }
   else
   {
     // check if the device id given matches a serial number of a connected device


### PR DESCRIPTION
# Issue
(Line added by @130s) Reported at https://github.com/ros-drivers/openni2_camera/issues/69

Openni2_driver checks if the device_id is a "oni" file. If so, it returns simply return the device_id.
Oni files were working on hydro version, but no more on indigo.
