### PR TITLE
Publish projector/camera_info (fixes disparity img)

### DIFF
--- a/include/openni2_camera/openni2_device.h
+++ b/include/openni2_camera/openni2_device.h
@@ -122,6 +122,7 @@ public:
   float getIRFocalLength (int output_y_resolution) const;
   float getColorFocalLength (int output_y_resolution) const;
   float getDepthFocalLength (int output_y_resolution) const;
+  float getBaseline () const;
 
   void setAutoExposure(bool enable) throw (OpenNI2Exception);
   void setAutoWhiteBalance(bool enable) throw (OpenNI2Exception);

--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -76,6 +76,7 @@ private:
   sensor_msgs::CameraInfoPtr getColorCameraInfo(int width, int height, ros::Time time) const;
   sensor_msgs::CameraInfoPtr getIRCameraInfo(int width, int height, ros::Time time) const;
   sensor_msgs::CameraInfoPtr getDepthCameraInfo(int width, int height, ros::Time time) const;
+  sensor_msgs::CameraInfoPtr getProjectorCameraInfo(int width, int height, ros::Time time) const;
 
   void readConfigFromParameterServer();
 
@@ -169,6 +170,7 @@ private:
   bool color_subscribers_;
   bool depth_subscribers_;
   bool depth_raw_subscribers_;
+  bool projector_info_subscribers_;
 
   bool use_device_time_;
 

--- a/src/openni2_device.cpp
+++ b/src/openni2_device.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "OpenNI.h"
+#include <PS1080.h> // For XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE property
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -169,6 +170,20 @@ float OpenNI2Device::getDepthFocalLength(int output_y_resolution) const
   }
 
   return focal_length;
+}
+
+float OpenNI2Device::getBaseline() const
+{
+  float baseline = 0.075f;
+  boost::shared_ptr<openni::VideoStream> stream = getDepthVideoStream();
+
+  if (stream && stream->isPropertySupported(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE))
+  {
+    double baseline_meters;
+    stream->getProperty(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE, &baseline_meters); // Device specific -- from PS1080.h
+    baseline = static_cast<float>(baseline_meters * 0.01f);  // baseline from cm -> meters
+  }
+  return baseline;
 }
 
 bool OpenNI2Device::isIRVideoModeSupported(const OpenNI2VideoMode& video_mode) const


### PR DESCRIPTION
Both `freenect_camera` and `openni_camera` publish the topic `/camera/projector/camera_info`, but `openni2_camera` didn't. This commit fixes that.

The topic is required for the disparity image to work (see ros-drivers/rgbd_launch#6). This PR is a port from the original openni_camera driver.

How to test:

    roslaunch openni2_launch openni2.launch disparity_processing:=true
    rosrun image_view disparity_view image:=/camera/depth/disparity

or:

    roslaunch openni2_launch openni2.launch depth_registration:=true disparity_registered_processing:=true
    rosrun image_view disparity_view image:=/camera/depth_registered/disparity