### PR TITLE
Add device re-connection

### DIFF
--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -85,6 +85,7 @@ private:
 
   void advertiseROSTopics();
 
+  void monitorConnection(const ros::TimerEvent& event);
   void colorConnectCb();
   void depthConnectCb();
   void irConnectCb();
@@ -104,6 +105,9 @@ private:
   void setColorVideoMode(const OpenNI2VideoMode& color_video_mode);
   void setDepthVideoMode(const OpenNI2VideoMode& depth_video_mode);
 
+  int extractBusID(const std::string& uri) const;
+  bool isConnected() const;
+
   ros::NodeHandle& nh_;
   ros::NodeHandle& pnh_;
 
@@ -111,6 +115,7 @@ private:
   boost::shared_ptr<OpenNI2Device> device_;
 
   std::string device_id_;
+  int bus_id_;
 
   /** \brief get_serial server*/
   ros::ServiceServer get_serial_server;
@@ -126,6 +131,9 @@ private:
   image_transport::CameraPublisher pub_depth_raw_;
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
+
+  // timer object
+  ros::Timer timer_;
 
   /** \brief Camera info manager objects. */
   boost::shared_ptr<camera_info_manager::CameraInfoManager> color_info_manager_, ir_info_manager_;

--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -108,6 +108,8 @@ private:
   int extractBusID(const std::string& uri) const;
   bool isConnected() const;
 
+  void forceSetExposure();
+
   ros::NodeHandle& nh_;
   ros::NodeHandle& pnh_;
 

--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -117,6 +117,9 @@ private:
   std::string device_id_;
   int bus_id_;
 
+  /** \brief indicates if reconnect logic is enabled. */
+  bool enable_reconnect_;
+
   /** \brief get_serial server*/
   ros::ServiceServer get_serial_server;
 
@@ -132,7 +135,7 @@ private:
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
 
-  // timer object
+  /** \brief timer for connection monitoring thread */
   ros::Timer timer_;
 
   /** \brief Camera info manager objects. */

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -394,6 +394,8 @@ void OpenNI2Driver::colorConnectCb()
     if( exposure_ != 0 )
     {
       ROS_INFO_STREAM("Exposure is set to " << exposure_ << ", forcing on color stream start");
+        //delay for stream to start, before setting exposure
+      boost::this_thread::sleep(boost::posix_time::milliseconds(100));
       forceSetExposure();
     }
 
@@ -907,7 +909,7 @@ void OpenNI2Driver::monitorConnection(const ros::TimerEvent &event)
         // be adjusted properly.  This is a work around for now, but the final
         // implimentation should only allow reconnection when auto exposure and
         // white balance are disabled, and FIXED exposure is used instead.
-        if(!auto_exposure_ || !auto_white_balance_)
+        if((!auto_exposure_ && !auto_white_balance_ ) && exposure_ == 0)
         {
           ROS_WARN_STREAM("Reconnection should not be enabled if auto expousre"
                           << "/white balance are disabled.  Temporarily working"


### PR DESCRIPTION
Fix #36.
Also includes a fix to #51, which would be an issue upon re-connection.
We've been testing this on a system that's running continuously.

Also see discussions in forked repo https://github.com/plusone-robotics/openni2_camera/pull/1, https://github.com/plusone-robotics/openni2_camera/pull/2

@stwirth I know it's been awhile since your original report #36 but if you could take a look that'll be great.
Of course anyone is welcomed for the review.

Credit goes to @shaun-edwards
