### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/ros/openni2_camera_nodelet.cpp
+++ b/ros/openni2_camera_nodelet.cpp
@@ -54,4 +54,4 @@ private:
 }
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(openni2_camera, OpenNI2DriverNodelet, openni2_camera::OpenNI2DriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(openni2_camera::OpenNI2DriverNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions