### PR TITLE
Remove unused ROS Parameters.

### DIFF
--- a/openni2_launch/launch/includes/device.launch
+++ b/openni2_launch/launch/includes/device.launch
@@ -9,8 +9,10 @@
   <arg name="depth_camera_info_url" />
   <arg name="depth_registration" default="true" />
   <arg name="color_depth_synchronization" default="false" />
-  <arg name="auto_exposure" default="true" />
-  <arg name="auto_white_balance" default="true" />
+  <arg name="auto_exposure" default="true"
+          doc="This arg is not used. Preserved only for backward compatibility." />
+  <arg name="auto_white_balance" default="true"
+          doc="This arg is not used. Preserved only for backward compatibility."  />
   <arg name="respawn" default="false" />
   <arg name="rgb"              default="rgb" />
   <arg name="ir"               default="ir" />

--- a/openni2_launch/launch/includes/device.launch.xml
+++ b/openni2_launch/launch/includes/device.launch.xml
@@ -16,8 +16,10 @@
   <arg name="depth_mode" default="5" />
   <arg name="depth_registration" default="true" />
   <arg name="color_depth_synchronization" default="false" />
-  <arg name="auto_exposure" default="true" />
-  <arg name="auto_white_balance" default="true" />
+  <arg name="auto_exposure" default="true"
+          doc="This arg is not used. Preserved only for backward compatibility." />
+  <arg name="auto_white_balance" default="true"
+          doc="This arg is not used. Preserved only for backward compatibility." />
 
   <arg name="respawn" default="false" />
   <arg     if="$(arg respawn)" name="bond" value="" />
@@ -45,8 +47,6 @@
 
     <param name="depth_registration" value="$(arg depth_registration)" />
     <param name="color_depth_synchronization" value="$(arg color_depth_synchronization)" />
-    <param name="auto_exposure" value="$(arg auto_exposure)" />
-    <param name="auto_white_balance" value="$(arg auto_white_balance)" />
 
     <remap from="ir" to="$(arg ir)" />
     <remap from="rgb" to="$(arg rgb)" />

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -23,8 +23,10 @@
 
   <!-- Driver parameters -->
   <arg name="color_depth_synchronization"     default="false" />
-  <arg name="auto_exposure"                   default="true" />
-  <arg name="auto_white_balance"              default="true" />
+  <arg name="auto_exposure"                   default="true"
+          doc="This arg is not used. Preserved only for backward compatibility." />
+  <arg name="auto_white_balance"              default="true"
+          doc="This arg is not used. Preserved only for backward compatibility." />
 
   <!-- Arguments for remapping all device namespaces -->
   <arg name="rgb"              default="rgb" />
@@ -82,8 +84,6 @@
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
-      <arg name="auto_exposure"                   value="$(arg auto_exposure)" />
-      <arg name="auto_white_balance"              value="$(arg auto_white_balance)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->

--- a/openni2_launch/launch/openni2_tf_prefix.launch
+++ b/openni2_launch/launch/openni2_tf_prefix.launch
@@ -24,8 +24,10 @@
 
   <!-- Driver parameters -->
   <arg name="color_depth_synchronization"     default="false" />
-  <arg name="auto_exposure"                   default="true" />
-  <arg name="auto_white_balance"              default="true" />
+  <arg name="auto_exposure"                   default="true"
+          doc="This arg is not used. Preserved only for backward compatibility."  />
+  <arg name="auto_white_balance"              default="true"
+          doc="This arg is not used. Preserved only for backward compatibility."  />
 
   <!-- Arguments for remapping all device namespaces -->
   <arg name="rgb"              default="rgb" />
@@ -83,8 +85,6 @@
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
-      <arg name="auto_exposure"                   value="$(arg auto_exposure)" />
-      <arg name="auto_white_balance"              value="$(arg auto_white_balance)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->


### PR DESCRIPTION
<s>**DONOT merge yet** but thoughts are welcomed.</s>

`auto_exposure` is defined as both ROS Parameter and Dynamic Reconfigure entry as you see in the following search result, and in the code only those dynamic reconf version is used.
In this PR Param versions are removed except `arg`s in launch file to retain backward compatibility of launch files.

There seems to be other Parameters in the same situation. I'll add those params too. -> UPDATE 20181019 I can't find them.

CC @MauleshSTrivedi who hinted for this finding.

```
$ git log -1
commit 21ea067c02dbb2f576410208fcb45b79e6fb1521
Author: Isaac I.Y. Saito <130s@2000.jukuin.keio.ac.jp>
Date:   Fri Nov 3 20:09:21 2017 -0700

    0.3.0

$ ack-grep -B 1 -A 1 -i auto_exposure .
openni2_camera/include/openni2_camera/openni2_driver.h
177-
178:  bool auto_exposure_;
179-  bool auto_white_balance_;

openni2_camera/cfg/OpenNI2.cfg
30-gen.add("color_depth_synchronization", bool_t, 0, "Synchronization of color and depth camera", False)
31:gen.add("auto_exposure", bool_t, 0, "Auto-Exposure", True)
32-gen.add("auto_white_balance", bool_t, 0, "Auto-White-Balance", True)

openni2_camera/src/openni2_driver.cpp
203-
204:  auto_exposure_ = config.auto_exposure;
205-  auto_white_balance_ = config.auto_white_balance;
--
298-  {
299:    if (!config_init_ || (old_config_.auto_exposure != auto_exposure_))
300:      device_->setAutoExposure(auto_exposure_);
301-  }
--
320-  // this check is always performed and exposure set.
321:  if( (!auto_exposure_ && !auto_white_balance_) && exposure_ != 0 )
322-  {
--
931-        // white balance are disabled, and FIXED exposure is used instead.
932:        if((!auto_exposure_ && !auto_white_balance_ ) && exposure_ == 0)
933-        {
--
944-          ROS_WARN_STREAM("Resetting auto exposure and white balance to previous values");
945:          device_->setAutoExposure(auto_exposure_);
946-          device_->setAutoWhiteBalance(auto_white_balance_);

openni2_launch/launch/includes/device.launch
11-  <arg name="color_depth_synchronization" default="false" />
12:  <arg name="auto_exposure" default="true" />
13-  <arg name="auto_white_balance" default="true" />

openni2_launch/launch/includes/device.launch.xml
18-  <arg name="color_depth_synchronization" default="false" />
19:  <arg name="auto_exposure" default="true" />
20-  <arg name="auto_white_balance" default="true" />
--
47-    <param name="color_depth_synchronization" value="$(arg color_depth_synchronization)" />
48:    <param name="auto_exposure" value="$(arg auto_exposure)" />
49-    <param name="auto_white_balance" value="$(arg auto_white_balance)" />

openni2_launch/launch/openni2_tf_prefix.launch
26-  <arg name="color_depth_synchronization"     default="false" />
27:  <arg name="auto_exposure"                   default="true" />
28-  <arg name="auto_white_balance"              default="true" />
--
85-      <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
86:      <arg name="auto_exposure"                   value="$(arg auto_exposure)" />
87-      <arg name="auto_white_balance"              value="$(arg auto_white_balance)" />

openni2_launch/launch/openni2.launch
25-  <arg name="color_depth_synchronization"     default="false" />
26:  <arg name="auto_exposure"                   default="true" />
27-  <arg name="auto_white_balance"              default="true" />
--
84-      <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
85:      <arg name="auto_exposure"                   value="$(arg auto_exposure)" />
86-      <arg name="auto_white_balance"              value="$(arg auto_white_balance)" />
```