### PR TITLE
Properly implement color/depth frame time synchronization

### DIFF
--- a/openni2_camera/include/openni2_camera/openni2_driver.h
+++ b/openni2_camera/include/openni2_camera/openni2_driver.h
@@ -169,6 +169,9 @@ private:
   ros::Duration color_time_offset_;
   ros::Duration depth_time_offset_;
 
+  ros::Time current_sync_color_depth_stamp_;
+  unsigned int sync_frame_index_;
+
   int data_skip_;
 
   int data_skip_ir_counter_;

--- a/openni2_camera/src/openni2_frame_listener.cpp
+++ b/openni2_camera/src/openni2_frame_listener.cpp
@@ -67,6 +67,8 @@ void OpenNI2FrameListener::onNewFrame(openni::VideoStream& stream)
   {
     sensor_msgs::ImagePtr image(new sensor_msgs::Image);
 
+    image->header.seq = m_frame.getFrameIndex();
+
     ros::Time ros_now = ros::Time::now();
 
     if (!user_device_timer_)


### PR DESCRIPTION
Frame synchronization, while available as an configurable option, has never been implemented properly. The PR ensures that matching frames have matching time stamps. This makes it possible to use the [ExactTime policy](http://wiki.ros.org/message_filters#ExactTime_Policy) to pair off the images later on.
