### PR TITLE
Add a simple roswtf plugin that checks the number of connected devices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,21 @@ env:
     - ROS_DISTRO="indigo" ROS_REPO=ros
     - ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed
     - ROS_DISTRO="indigo" PRERELEASE=true
-    - ROS_DISTRO="jade"   ROS_REPO=ros
     - ROS_DISTRO="kinetic"   ROS_REPO=ros ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
     - ROS_DISTRO="kinetic"   ROS_REPO=ros-shadow-fixed ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
     - ROS_DISTRO="kinetic"   PRERELEASE=true
-    - ROS_DISTRO="lunar"   ROS_REPO=ros ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
-    - ROS_DISTRO="lunar"   ROS_REPO=ros-shadow-fixed ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
+    - ROS_DISTRO="lunar"   ROS_REPO=ros
+    - ROS_DISTRO="lunar"   ROS_REPO=ros-shadow-fixed
     - ROS_DISTRO="lunar"   PRERELEASE=true
+    - ROS_DISTRO="melodic"   ROS_REPO=ros ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
+    - ROS_DISTRO="melodic"   ROS_REPO=ros-shadow-fixed ABICHECK_URL='github:ros-drivers/openni2_camera#indigo-devel'
+    - ROS_DISTRO="melodic"   PRERELEASE=true
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="indigo"  PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
     - env: ROS_DISTRO="indigo" PRERELEASE=true
-    - env: ROS_DISTRO="jade"   ROS_REPO=ros
     - env: ROS_DISTRO="kinetic"   PRERELEASE=true
     - env: ROS_DISTRO="lunar"   PRERELEASE=true
+    - env: ROS_DISTRO="melodic"   PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/openni2_launch/CMakeLists.txt
+++ b/openni2_launch/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(openni2_launch)
 
 find_package(catkin)
-
+catkin_python_setup()
 catkin_package()
 
 install(DIRECTORY launch

--- a/openni2_launch/doc/index.rst
+++ b/openni2_launch/doc/index.rst
@@ -45,6 +45,78 @@ E.g. When 2 openni2-based cameras are connected and `lsusb -t` returns the follo
 
 TBD
 
+Support tools
+==========
+
+Check the number of devices plugged in by `roswtf plugin <http://wiki.ros.org/roswtf/Plugins>`_.
+Change the number of devices to expect by setting the number in ROS parameter "``openni2_num_sensors_expected``".
+
+Example: ::
+
+  $ lsusb
+  :
+  Bus 005 Device 002: ID 1d27:0601 ASUS 
+  Bus 003 Device 002: ID 1d27:0601 ASUS 
+  
+  term-1$ roscore
+  
+  term-2$ roswtf
+  
+  Loaded plugin tf.tfwtf
+  Loaded plugin openni2_launch.wtf_plugin
+  No package or stack in context
+  ================================================================================
+  Static checks summary:
+  
+  Found 1 error(s).
+  
+  ERROR Different number of openni2 sensors found.
+   * 2 openni2 sensors found (expected: 1).
+  
+  ================================================================================
+  Beginning tests of your ROS graph. These may take awhile...
+  analyzing graph...
+  ... done analyzing graph
+  running graph rules...
+  ... done running graph rules
+  
+  Online checks summary:
+  
+  Found 1 warning(s).
+  Warnings are things that may be just fine, but are sometimes at fault
+  
+  WARNING The following node subscriptions are unconnected:
+   * /rosout:
+     * /rosout
+
+After setting `openni2_num_sensors_expected` param with 2, no error occurs. ::
+
+  term-2$ rosparam set openni2_num_sensors_expected 2
+  
+  $ roswtf                                                                                                                                                                    
+  Loaded plugin tf.tfwtf
+  Loaded plugin openni2_launch.wtf_plugin
+  No package or stack in context
+  ================================================================================
+  Static checks summary:
+  
+  No errors or warnings
+  ================================================================================
+  Beginning tests of your ROS graph. These may take awhile...
+  analyzing graph...
+  ... done analyzing graph
+  running graph rules...
+  ... done running graph rules
+
+  Online checks summary:
+  
+  Found 1 warning(s).
+  Warnings are things that may be just fine, but are sometimes at fault
+  
+  WARNING The following node subscriptions are unconnected:
+   * /rosout:
+     * /rosout
+
 Indices and tables
 ==================
 

--- a/openni2_launch/launch/includes/device.launch.xml
+++ b/openni2_launch/launch/includes/device.launch.xml
@@ -6,6 +6,8 @@
 
   <!-- Driver parameters -->
   <arg name="device_id" />
+  <arg name="id_manufacturer" />
+  <arg name="id_product" />
   <arg name="rgb_frame_id" />
   <arg name="depth_frame_id" />
   <arg name="rgb_camera_info_url" />
@@ -34,6 +36,8 @@
         args="load openni2_camera/OpenNI2DriverNodelet $(arg manager) $(arg bond)"
 	    respawn="$(arg respawn)">
     <param name="device_id" type="str" value="$(arg device_id)" />
+    <param name="id_manufacturer" type="str" value="$(arg id_manufacturer)" />
+    <param name="id_product" type="str" value="$(arg id_product)" />
     <param name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />
     <param name="depth_camera_info_url" value="$(arg depth_camera_info_url)" />
     <param name="rgb_frame_id"   value="$(arg rgb_frame_id)" />

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -12,6 +12,11 @@
             '#1'  : the first device found
             '2@X' : the Xth device on USB bus 2"/>
 
+  <arg name="id_manufacturer" default="1d27"
+       doc="Vendor ID of the sensor (maintained at http://www.linux-usb.org/usb-ids.html). Default: ASUS."/>
+  <arg name="id_product" default="0601"
+       doc="Product ID of the sensor. Default: Xtion."/>
+
   <arg name="rgb_camera_info_url"   default=""
        doc="By default, calibrations are stored to file://${ROS_HOME}/camera_info/${NAME}.yaml,
             where ${NAME} is of the form '[rgb|depth]_[serial#]', e.g. 'depth_B00367707227042B'.
@@ -72,6 +77,8 @@
 	     file="$(find openni2_launch)/launch/includes/device.launch.xml">
       <arg name="manager"                         value="$(arg manager)" />
       <arg name="device_id"                       value="$(arg device_id)" />
+      <arg name="id_manufacturer"                 value="$(arg id_manufacturer)" />
+      <arg name="id_product"                      value="$(arg id_product)" />
       <arg name="rgb_frame_id"                    value="$(arg rgb_frame_id)" />
       <arg name="depth_frame_id"                  value="$(arg depth_frame_id)" />
       <arg name="rgb_camera_info_url"             value="$(arg rgb_camera_info_url)" />

--- a/openni2_launch/package.xml
+++ b/openni2_launch/package.xml
@@ -17,8 +17,12 @@
   <run_depend>image_proc</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>openni2_camera</run_depend>
+  <run_depend>python-pyusb-pip</run_depend>   
+  <run_depend>rospy</run_depend>
+  <run_depend>roswtf</run_depend>  
   <run_depend>tf</run_depend>
   <export>
     <rosdoc config="rosdoc.yaml"/>  
+    <roswtf plugin="openni2_launch.wtf_plugin" />    
   </export>
 </package>

--- a/openni2_launch/package.xml
+++ b/openni2_launch/package.xml
@@ -17,7 +17,6 @@
   <run_depend>image_proc</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>openni2_camera</run_depend>
-  <run_depend>python-usb</run_depend>   
   <run_depend>rospy</run_depend>
   <run_depend>roswtf</run_depend>  
   <run_depend>tf</run_depend>

--- a/openni2_launch/package.xml
+++ b/openni2_launch/package.xml
@@ -17,7 +17,7 @@
   <run_depend>image_proc</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>openni2_camera</run_depend>
-  <run_depend>python-pyusb-pip</run_depend>   
+  <run_depend>python-usb</run_depend>   
   <run_depend>rospy</run_depend>
   <run_depend>roswtf</run_depend>  
   <run_depend>tf</run_depend>

--- a/openni2_launch/setup.py
+++ b/openni2_launch/setup.py
@@ -1,0 +1,11 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=["openni2_launch"],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/openni2_launch/src/openni2_launch/wtf_plugin.py
+++ b/openni2_launch/src/openni2_launch/wtf_plugin.py
@@ -79,10 +79,11 @@ def sensor_notfound(ctx):
     """
     errors = []
     num_sensors_expected = rospy.get_param("openni2_num_sensors_expected", 1)
-    # TODO: The set of manufacture id and prod id is specific to Asus Xtion.
-    #       There may be other openni2-based devices.
+    # The set of manufacture id and prod id. Default: Asus Xtion.
+    id_manufacturer = rospy.get_param("id_manufacturer", "1d27")
+    id_product = rospy.get_param("id_product", "0601")
     devices = _device_notfound_subproc(
-        id_manufacturer="1d27", id_product="0601")
+        id_manufacturer=id_manufacturer, id_product=id_product)
     num_sensors = len(devices)
     if num_sensors != num_sensors_expected:
         errors.append("{} openni2 sensors found (expected: {}).".format(

--- a/openni2_launch/src/openni2_launch/wtf_plugin.py
+++ b/openni2_launch/src/openni2_launch/wtf_plugin.py
@@ -1,0 +1,85 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, PlusOne Robotics, Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Plus One Robotics, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+import re
+import subprocess
+
+import rospy
+from roswtf.rules import warning_rule, error_rule
+
+
+def sensor_notfound(ctx):
+    """
+    @summary: Check if expected number of sensors are found.
+                          Expected number of sensors can be set by
+                          ROS Parameter 'openni2_num_sensors_expected'.
+    """
+    errors = []
+    num_sensors_expected = rospy.get_param("openni2_num_sensors_expected", 1)
+    # TODO: The set of manufacture id and prod id is specific to Asus Xtion.
+    #       There may be other openni2-based devices.
+    devices = usb.core.find(idVendor=0x1d27, idProduct=0x0601, find_all=True)
+    num_sensors = sum(1 for _ in devices)
+    if num_sensors != num_sensors_expected:
+        errors.append("{} openni2 sensors found (expected: {}).".format(
+            num_sensors, num_sensors_expected))
+    return errors
+
+
+# app_warnings and app_errors declare the rules that we actually check
+app_warnings_online = [
+]
+
+app_warnings_static = [
+]
+
+app_errors_online = [
+]
+
+app_errors_static = [
+  (sensor_notfound, "Different number of openni2 sensors found."),
+]
+
+
+# roswtf entry point for online checks
+def roswtf_plugin_online(ctx):
+    for r in app_warnings_online:
+        warning_rule(r, r[0](ctx), ctx)
+    for r in app_errors_online:
+        error_rule(r, r[0](ctx), ctx)
+
+
+def roswtf_plugin_static(ctx):
+    for r in app_warnings_static:
+        warning_rule(r, r[0](ctx), ctx)
+    for r in app_errors_static:
+        error_rule(r, r[0](ctx), ctx)

--- a/openni2_launch/src/openni2_launch/wtf_plugin.py
+++ b/openni2_launch/src/openni2_launch/wtf_plugin.py
@@ -71,8 +71,11 @@ def _device_notfound_subproc(id_manufacturer, id_product):
 def sensor_notfound(ctx):
     """
     @summary: Check if expected number of sensors are found.
-                          Expected number of sensors can be set by
-                          ROS Parameter 'openni2_num_sensors_expected'.
+              Expected number of sensors can be set by
+              ROS Parameter 'openni2_num_sensors_expected'.
+    @note: Technically this can be static check, but because of the
+           need for connecting to ROS Param server, this needs
+           to be online check.
     """
     errors = []
     num_sensors_expected = rospy.get_param("openni2_num_sensors_expected", 1)
@@ -95,10 +98,10 @@ app_warnings_static = [
 ]
 
 app_errors_online = [
+  (sensor_notfound, "Different number of openni2 sensors found."),
 ]
 
 app_errors_static = [
-  (sensor_notfound, "Different number of openni2 sensors found."),
 ]
 
 


### PR DESCRIPTION
In some applications specific number of sensors are required to run as expected. This PR adds [roswtf plugin](http://wiki.ros.org/roswtf/Plugins) to check the number of the sensors plugged in to the computer your application runs on.

Example: by plugging 2 sensors, the check fail if `openni2_num_sensors` is not changed (default=1).
```
$ lsusb
:
Bus 005 Device 002: ID 1d27:0601 ASUS 
Bus 003 Device 002: ID 1d27:0601 ASUS 

term-1$ roscore

term-2$ roswtf

Loaded plugin tf.tfwtf
Loaded plugin openni2_launch.wtf_plugin
No package or stack in context
================================================================================
Static checks summary:

Found 1 error(s).

ERROR One or more openni2 sensors not found.
 * 2 openni2 sensors found while 1 expected.

================================================================================
Beginning tests of your ROS graph. These may take awhile...
analyzing graph...
... done analyzing graph
running graph rules...
... done running graph rules

Online checks summary:

Found 1 warning(s).
Warnings are things that may be just fine, but are sometimes at fault

WARNING The following node subscriptions are unconnected:
 * /rosout:
   * /rosout
```
After setting `openni2_num_sensors` param with 2, no error occurs.
```
term-2$ rosparam set openni2_num_sensors 2

$ roswtf                                                                                                                                                                    
Loaded plugin tf.tfwtf
Loaded plugin openni2_launch.wtf_plugin
No package or stack in context
================================================================================
Static checks summary:

No errors or warnings
================================================================================
Beginning tests of your ROS graph. These may take awhile...
analyzing graph...
... done analyzing graph
running graph rules...
... done running graph rules

Online checks summary:

Found 1 warning(s).
Warnings are things that may be just fine, but are sometimes at fault

WARNING The following node subscriptions are unconnected:
 * /rosout:
   * /rosout
```
