### PR TITLE
Fix missing dependency on roswtf plugin.

### DIFF
--- a/openni2_launch/package.xml
+++ b/openni2_launch/package.xml
@@ -21,6 +21,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>roswtf</run_depend>  
   <run_depend>tf</run_depend>
+  <run_depend>usbutils</run_depend>
   <export>
     <rosdoc config="rosdoc.yaml"/>  
     <roswtf plugin="openni2_launch.wtf_plugin" />    


### PR DESCRIPTION
This depends on https://github.com/ros/rosdistro/pull/19379

Without usbutils installed/available, `roswtf` plugin fails with unintuitive error message like the following.

```

Loaded plugin tf.tfwtf
Loaded plugin openni2_launch.wtf_plugin
No package or stack in context
================================================================================
Static checks summary:

Found 1 warning(s).
Warnings are things that may be just fine, but are sometimes at fault

:

================================================================================
Beginning tests of your ROS graph. These may take awhile...
analyzing graph...
... done analyzing graph
running graph rules...
... done running graph rules
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roswtf/__init__.py", line 224, in _roswtf_main
      p(ctx)
        File "/opt/ros/kinetic/lib/python2.7/dist-packages/openni2_launch/wtf_plugin.py", line 114, in roswtf_plugin_online
    error_rule(r, r[0](ctx), ctx)
      File "/opt/ros/kinetic/lib/python2.7/dist-packages/openni2_launch/wtf_plugin.py", line 86, in sensor_notfound
          id_manufacturer=id_manufacturer, id_product=id_product)
    File "/opt/ros/kinetic/lib/python2.7/dist-packages/openni2_launch/wtf_plugin.py", line 56, in _device_notfound_subproc
        df = subprocess.check_output("lsusb")
  File "/usr/lib/python2.7/subprocess.py", line 567, in check_output
      process = Popen(stdout=PIPE, *popenargs, **kwargs)
        File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
      File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
          raise child_exception
OSError: [Errno 2] No such file or directory
[Errno 2] No such file or directory
```