### PR TITLE
Readd mode arguments to openni2.launch

### DIFF
--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -32,6 +32,9 @@
           doc="This arg is not used. Preserved only for backward compatibility." />
   <arg name="auto_white_balance"              default="true"
           doc="This arg is not used. Preserved only for backward compatibility." />
+  <arg name="color_mode"            default="5" />
+  <arg name="ir_mode"               default="5" />
+  <arg name="depth_mode"            default="5" />
 
   <!-- Arguments for remapping all device namespaces -->
   <arg name="rgb"              default="rgb" />
@@ -88,6 +91,9 @@
       <arg name="rgb"                             value="$(arg rgb)" />
       <arg name="ir"                              value="$(arg ir)" />
       <arg name="depth"                           value="$(arg depth)" />
+      <arg name="color_mode"                      value="$(arg color_mode)" />
+      <arg name="ir_mode"                         value="$(arg ir_mode)" />
+      <arg name="depth_mode"                      value="$(arg depth_mode)" />
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />

--- a/openni2_launch/package.xml
+++ b/openni2_launch/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="3">
   <name>openni2_launch</name>
   <version>0.4.2</version>
   <description>
@@ -11,17 +12,18 @@
   <author email="developers@unboundedrobotics.com">Michael Ferguson</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>python-catkin-pkg</build_depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</depend>
   <build_depend>roslaunch</build_depend>  <!-- For launch check -->
-  <run_depend>rgbd_launch</run_depend>
-  <run_depend>depth_image_proc</run_depend>
-  <run_depend>image_proc</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>openni2_camera</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>roswtf</run_depend>  
-  <run_depend>tf</run_depend>
-  <run_depend>usbutils</run_depend>
+  <exec_depend>rgbd_launch</exec_depend>
+  <exec_depend>depth_image_proc</exec_depend>
+  <exec_depend>image_proc</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend>openni2_camera</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>roswtf</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>usbutils</exec_depend>
   <export>
     <rosdoc config="rosdoc.yaml"/>  
     <roswtf plugin="openni2_launch.wtf_plugin" />    


### PR DESCRIPTION
These args were lost on https://github.com/ros-drivers/openni2_camera/commit/576b616023175f75028430f47c2f72184cfa4587

Afaik there's no other way to specify at startup the mode, and changing the mode after the node is running via dynamic reconfigure is something that we'd like to avoid.