### PR TITLE
[backport into indigo-devel]  Use serialnumber in camera names 

### DIFF
--- a/openni2_camera/include/openni2_camera/openni2_driver.h
+++ b/openni2_camera/include/openni2_camera/openni2_driver.h
@@ -123,6 +123,15 @@ private:
   /** \brief indicates if reconnect logic is enabled. */
   bool enable_reconnect_;
 
+  /** \brief indicates if the serialnumber is used in the camera names.
+   * Default is false. The name is based on the device and vendor name.
+   * This produces non-unique camera names, if multiple camaras of the
+   * same type are used on the same machine.
+   * Set to true, to get names with serialnumber. The names will always
+   * be unique. This matches the 'openni' behaviour.
+   */
+  bool serialnumber_as_name_;
+
   /** \brief get_serial server*/
   ros::ServiceServer get_serial_server;
 

--- a/openni2_camera/src/openni2_driver.cpp
+++ b/openni2_camera/src/openni2_driver.cpp
@@ -53,7 +53,8 @@ OpenNI2Driver::OpenNI2Driver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
     color_subscribers_(false),
     depth_subscribers_(false),
     depth_raw_subscribers_(false),
-    enable_reconnect_(false)
+    enable_reconnect_(false),
+    serialnumber_as_name_(false)
 {
 
   genVideoModeTableMap();
@@ -142,9 +143,13 @@ void OpenNI2Driver::advertiseROSTopics()
 
   // The camera names are set to [rgb|depth]_[serial#], e.g. depth_B00367707227042B.
   // camera_info_manager substitutes this for ${NAME} in the URL.
-  std::string serial_number = device_manager_->getSerial(device_->getUri());
-  std::string color_name, ir_name;
+  std::string serial_number;
+  if (serialnumber_as_name_)
+    serial_number = device_manager_->getSerial(device_->getUri());
+  else
+    serial_number = device_->getStringID();
 
+  std::string color_name, ir_name;
   color_name = "rgb_"   + serial_number;
   ir_name  = "depth_" + serial_number;
 
@@ -713,6 +718,8 @@ void OpenNI2Driver::readConfigFromParameterServer()
   pnh_.param("depth_camera_info_url", ir_info_url_, std::string());
 
   pnh_.param("enable_reconnect", enable_reconnect_, true);
+
+  pnh_.param("serialnumber_as_name", serialnumber_as_name_, false);
 
 }
 

--- a/openni2_camera/src/openni2_driver.cpp
+++ b/openni2_camera/src/openni2_driver.cpp
@@ -142,7 +142,7 @@ void OpenNI2Driver::advertiseROSTopics()
 
   // The camera names are set to [rgb|depth]_[serial#], e.g. depth_B00367707227042B.
   // camera_info_manager substitutes this for ${NAME} in the URL.
-  std::string serial_number = device_->getStringID();
+  std::string serial_number = device_manager_->getSerial(device_->getUri());
   std::string color_name, ir_name;
 
   color_name = "rgb_"   + serial_number;

--- a/openni2_launch/launch/includes/color.launch
+++ b/openni2_launch/launch/includes/color.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Load processing nodelets for the Color camera -->
 <launch>
 

--- a/openni2_launch/launch/includes/depth.launch
+++ b/openni2_launch/launch/includes/depth.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Load processing nodelets for the depth camera -->
 <launch>
 

--- a/openni2_launch/launch/includes/device.launch
+++ b/openni2_launch/launch/includes/device.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->

--- a/openni2_launch/launch/includes/device.launch.xml
+++ b/openni2_launch/launch/includes/device.launch.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Launch the OpenNI2 device driver -->
 <launch>
 

--- a/openni2_launch/launch/includes/device.launch.xml
+++ b/openni2_launch/launch/includes/device.launch.xml
@@ -28,6 +28,9 @@
   <arg     if="$(arg respawn)" name="bond" value="" />
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
 
+  <arg name="enable_reconnect" default="true"
+       doc="Reconnect to device" />
+
   <!-- Remapping arguments -->
   <arg name="rgb"              default="rgb" />
   <arg name="ir"               default="ir" />
@@ -52,6 +55,8 @@
 
     <param name="depth_registration" value="$(arg depth_registration)" />
     <param name="color_depth_synchronization" value="$(arg color_depth_synchronization)" />
+
+    <param name="enable_reconnect" value="$(arg enable_reconnect)" />
 
     <remap from="ir" to="$(arg ir)" />
     <remap from="rgb" to="$(arg rgb)" />

--- a/openni2_launch/launch/includes/device.launch.xml
+++ b/openni2_launch/launch/includes/device.launch.xml
@@ -31,6 +31,9 @@
   <arg name="enable_reconnect" default="true"
        doc="Reconnect to device" />
 
+  <arg name="serialnumber_as_name" default="false"
+       doc="Use the serialnumber as the device name. True matches openni_camera behaviour" />
+
   <!-- Remapping arguments -->
   <arg name="rgb"              default="rgb" />
   <arg name="ir"               default="ir" />
@@ -57,6 +60,7 @@
     <param name="color_depth_synchronization" value="$(arg color_depth_synchronization)" />
 
     <param name="enable_reconnect" value="$(arg enable_reconnect)" />
+    <param name="serialnumber_as_name" value="$(arg serialnumber_as_name)" />
 
     <remap from="ir" to="$(arg ir)" />
     <remap from="rgb" to="$(arg rgb)" />

--- a/openni2_launch/launch/includes/ir.launch
+++ b/openni2_launch/launch/includes/ir.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->

--- a/openni2_launch/launch/includes/manager.launch
+++ b/openni2_launch/launch/includes/manager.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->

--- a/openni2_launch/launch/includes/pointclouds.launch
+++ b/openni2_launch/launch/includes/pointclouds.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Load processing nodelets for the Color camera -->
 <launch>
 

--- a/openni2_launch/launch/includes/processing.launch
+++ b/openni2_launch/launch/includes/processing.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->

--- a/openni2_launch/launch/kinect_frames.launch
+++ b/openni2_launch/launch/kinect_frames.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Entry point for using OpenNI2 devices -->
 <launch>
 

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -66,6 +66,9 @@
   <arg name="enable_reconnect" default="true"
        doc="Reconnect to device" />
 
+  <arg name="serialnumber_as_name" default="false"
+       doc="Use the serialnumber as the device name. True matches openni_camera behaviour" />
+
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
 
@@ -96,6 +99,7 @@
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
       <arg name="enable_reconnect"                value="$(arg enable_reconnect)" />
+      <arg name="serialnumber_as_name"            value="$(arg serialnumber_as_name)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -65,19 +65,19 @@
 
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
-  
-	  <!-- Start nodelet manager -->
-	  <arg name="manager" value="$(arg camera)_nodelet_manager" />
-	  <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
-	  <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
-	    <arg name="name" value="$(arg manager)" />
-	    <arg name="debug" value="$(arg debug)" />
-	    <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
-	  </include>
+
+    <!-- Start nodelet manager -->
+    <arg name="manager" value="$(arg camera)_nodelet_manager" />
+    <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
+    <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
+      <arg name="name" value="$(arg manager)" />
+      <arg name="debug" value="$(arg debug)" />
+      <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
+    </include>
 
     <!-- Load driver -->
     <include if="$(arg load_driver)"
-	     file="$(find openni2_launch)/launch/includes/device.launch.xml">
+      file="$(find openni2_launch)/launch/includes/device.launch.xml">
       <arg name="manager"                         value="$(arg manager)" />
       <arg name="device_id"                       value="$(arg device_id)" />
       <arg name="id_manufacturer"                 value="$(arg id_manufacturer)" />
@@ -116,7 +116,7 @@
 
   <!-- Load reasonable defaults for the relative pose between cameras -->
   <include if="$(arg publish_tf)"
-	   file="$(find rgbd_launch)/launch/kinect_frames.launch">
+    file="$(find rgbd_launch)/launch/kinect_frames.launch">
     <arg name="camera" value="$(arg camera)" />
   </include>
 

--- a/openni2_launch/launch/openni2.launch
+++ b/openni2_launch/launch/openni2.launch
@@ -63,6 +63,9 @@
   <arg name="num_worker_threads" default="4"
        doc="Worker threads for the nodelet manager" />
 
+  <arg name="enable_reconnect" default="true"
+       doc="Reconnect to device" />
+
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
 
@@ -92,6 +95,7 @@
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
+      <arg name="enable_reconnect"                value="$(arg enable_reconnect)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->

--- a/openni2_launch/launch/openni2_tf_prefix.launch
+++ b/openni2_launch/launch/openni2_tf_prefix.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <!-- Entry point for using OpenNI2 devices (if you still use tf_prefix) -->
 <launch>
 

--- a/openni2_launch/launch/openni2_tf_prefix.launch
+++ b/openni2_launch/launch/openni2_tf_prefix.launch
@@ -67,6 +67,9 @@
   <arg name="enable_reconnect" default="true"
        doc="Reconnect to device" />
 
+  <arg name="serialnumber_as_name" default="false"
+       doc="Use the serialnumber as the device name. True matches openni_camera behaviour" />
+
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
 
@@ -97,6 +100,7 @@
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
       <arg name="enable_reconnect"                value="$(arg enable_reconnect)" />
+      <arg name="serialnumber_as_name"            value="$(arg serialnumber_as_name)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->

--- a/openni2_launch/launch/openni2_tf_prefix.launch
+++ b/openni2_launch/launch/openni2_tf_prefix.launch
@@ -2,48 +2,48 @@
 <!-- Entry point for using OpenNI2 devices (if you still use tf_prefix) -->
 <launch>
 
-  <!-- "camera" should uniquely identify the device. All topics are pushed down
-       into the "camera" namespace, and it is prepended to tf frame ids. -->
-  <arg name="camera" default="camera" />
+  <arg name="camera" default="camera"
+       doc="'camera' should uniquely identify the device. All topics are pushed down
+            into the 'camera' namespace, and it is prepended to tf frame ids." />
   <arg name="tf_prefix" default="" />
-  <arg name="rgb_frame_id"   default="$(arg tf_prefix)/$(arg camera)_rgb_optical_frame" />
-  <arg name="depth_frame_id" default="$(arg tf_prefix)/$(arg camera)_depth_optical_frame" />
+  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
 
-  <!-- device_id can have the following formats:
-         "#1"  : the first device found
-         "2@X" : the Xth device on USB bus 2 -->
-  <arg name="device_id" default="#1" />
+  <arg name="device_id" default="#1"
+       doc="device_id can have the following formats:
+            '#1'  : the first device found
+            '2@X' : the Xth device on USB bus 2"/>
 
- <arg name="id_manufacturer" default="1d27"
+  <arg name="id_manufacturer" default="1d27"
        doc="Vendor ID of the sensor (maintained at http://www.linux-usb.org/usb-ids.html). Default: ASUS."/>
   <arg name="id_product" default="0601"
        doc="Product ID of the sensor. Default: Xtion."/>
 
-  <!-- By default, calibrations are stored to file://${ROS_HOME}/camera_info/${NAME}.yaml,
-       where ${NAME} is of the form "[rgb|depth]_[serial#]", e.g. "depth_B00367707227042B".
-       See camera_info_manager docs for calibration URL details. -->
-  <arg name="rgb_camera_info_url"   default="" />
+  <arg name="rgb_camera_info_url"   default=""
+       doc="By default, calibrations are stored to file://${ROS_HOME}/camera_info/${NAME}.yaml,
+            where ${NAME} is of the form '[rgb|depth]_[serial#]', e.g. 'depth_B00367707227042B'.
+            See camera_info_manager docs for calibration URL details." />
   <arg name="depth_camera_info_url" default="" />
 
-  <!-- Hardware depth registration -->
-  <arg name="depth_registration" default="false" />
+  <arg name="depth_registration" default="false"
+       doc="Hardware depth registration" />
 
   <!-- Driver parameters -->
   <arg name="color_depth_synchronization"     default="false" />
   <arg name="auto_exposure"                   default="true"
-          doc="This arg is not used. Preserved only for backward compatibility."  />
+          doc="This arg is not used. Preserved only for backward compatibility." />
   <arg name="auto_white_balance"              default="true"
-          doc="This arg is not used. Preserved only for backward compatibility."  />
+          doc="This arg is not used. Preserved only for backward compatibility." />
 
   <!-- Arguments for remapping all device namespaces -->
   <arg name="rgb"              default="rgb" />
   <arg name="ir"               default="ir" />
   <arg name="depth"            default="depth" />
 
-  <!-- Optionally suppress loading the driver nodelet and/or publishing the default tf
+  <arg name="load_driver" default="true"
+       doc="Optionally suppress loading the driver nodelet and/or publishing the default tf
        tree. Useful if you are playing back recorded raw data from a bag, or are
-       supplying a more accurate tf tree from calibration. -->
-  <arg name="load_driver" default="true" />
+       supplying a more accurate tf tree from calibration." />
   <arg name="publish_tf" default="true" />
   <!-- Processing Modules -->
   <arg name="rgb_processing"                  default="true"  />
@@ -58,27 +58,27 @@
   <arg name="hw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <arg name="sw_registered_processing"        default="true" unless="$(arg depth_registration)" />
 
-  <!-- Disable bond topics by default -->
-  <arg name="respawn" default="false" />
+  <arg name="respawn" default="false"
+       doc="Disable bond topics by default" />
 
-  <!-- Worker threads for the nodelet manager -->
-  <arg name="num_worker_threads" default="4" />
+  <arg name="num_worker_threads" default="4"
+       doc="Worker threads for the nodelet manager" />
 
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
-  
-	  <!-- Start nodelet manager -->
-	  <arg name="manager" value="$(arg camera)_nodelet_manager" />
-	  <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
-	  <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
-	    <arg name="name" value="$(arg manager)" />
-	    <arg name="debug" value="$(arg debug)" />
-	    <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
-	  </include>
+
+    <!-- Start nodelet manager -->
+    <arg name="manager" value="$(arg camera)_nodelet_manager" />
+    <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
+    <include file="$(find rgbd_launch)/launch/includes/manager.launch.xml">
+      <arg name="name" value="$(arg manager)" />
+      <arg name="debug" value="$(arg debug)" />
+      <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
+    </include>
 
     <!-- Load driver -->
     <include if="$(arg load_driver)"
-	     file="$(find openni2_launch)/launch/includes/device.launch.xml">
+      file="$(find openni2_launch)/launch/includes/device.launch.xml">
       <arg name="manager"                         value="$(arg manager)" />
       <arg name="device_id"                       value="$(arg device_id)" />
       <arg name="id_manufacturer"                 value="$(arg id_manufacturer)" />
@@ -117,7 +117,7 @@
 
   <!-- Load reasonable defaults for the relative pose between cameras -->
   <include if="$(arg publish_tf)"
-	   file="$(find rgbd_launch)/launch/kinect_frames.launch">
+    file="$(find rgbd_launch)/launch/kinect_frames.launch">
     <arg name="camera" value="$(arg camera)" />
     <arg name="tf_prefix" value="$(arg tf_prefix)" />
   </include>

--- a/openni2_launch/launch/openni2_tf_prefix.launch
+++ b/openni2_launch/launch/openni2_tf_prefix.launch
@@ -64,6 +64,9 @@
   <arg name="num_worker_threads" default="4"
        doc="Worker threads for the nodelet manager" />
 
+  <arg name="enable_reconnect" default="true"
+       doc="Reconnect to device" />
+
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
 
@@ -93,6 +96,7 @@
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="depth_registration"              value="$(arg depth_registration)" />
       <arg name="color_depth_synchronization"     value="$(arg color_depth_synchronization)" />
+      <arg name="enable_reconnect"                value="$(arg enable_reconnect)" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->


### PR DESCRIPTION
Same changes as #101 into `indigo-devel`.

Part of https://github.com/ros-drivers/openni2_camera/issues/103

# CoS
- [ ] CI pass for ROS M, K