### PR TITLE
make subprocess output a string instead of bytes, needed in python 3.7

### DIFF
--- a/openni2_camera/ros/openni2_camera_nodelet.cpp
+++ b/openni2_camera/ros/openni2_camera_nodelet.cpp
@@ -53,5 +53,5 @@ private:
 
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(openni2_camera::OpenNI2DriverNodelet, nodelet::Nodelet)

--- a/openni2_launch/src/openni2_launch/wtf_plugin.py
+++ b/openni2_launch/src/openni2_launch/wtf_plugin.py
@@ -53,7 +53,7 @@ def _device_notfound_subproc(id_manufacturer, id_product):
                  can be wiped out. See https://github.com/ros-drivers/openni2_camera/pull/80#discussion_r193295442
     """
     device_re = re.compile("Bus\s+(?P<bus>\d+)\s+Device\s+(?P<device>\d+).+ID\s(?P<id>\w+:\w+)\s(?P<tag>.+)$", re.I)
-    df = subprocess.check_output("lsusb")
+    df = subprocess.check_output("lsusb", text=True)
     devices = []
     for i in df.split('\n'):
         if i:


### PR DESCRIPTION
Running `roswtf` resulted in this exception on Ubuntu 20.04 and ros noetic both in the apt released version and current source here:

```
running tf checks, this will take a second...
... tf checks complete
Traceback (most recent call last):
  File "<string>", line 224, in _roswtf_main
  File "/opt/ros/noetic/lib/python3/dist-packages/openni2_launch/wtf_plugin.py", line 114, in roswtf_plugin_online
    error_rule(r, r[0](ctx), ctx)
  File "/opt/ros/noetic/lib/python3/dist-packages/openni2_launch/wtf_plugin.py", line 85, in sensor_notfound
    devices = _device_notfound_subproc(
  File "/opt/ros/noetic/lib/python3/dist-packages/openni2_launch/wtf_plugin.py", line 58, in _device_notfound_subproc
    for i in df.split('\n'):
TypeError: a bytes-like object is required, not 'str'
a bytes-like object is required, not 'str'
```

Adding `text=True` to the subprocess call looks to be the correct thing to do in newer python versions:

https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.stdout

https://stackoverflow.com/questions/5902485/can-i-have-subprocess-call-write-the-output-of-the-call-to-a-string