### PR TITLE
add depth_image_proc exec dep

### DIFF
--- a/openni2_camera/package.xml
+++ b/openni2_camera/package.xml
@@ -22,6 +22,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>image_transport</depend>
+  <exec_depend>depth_image_proc</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
Needed when starting the camera with point cloud processing.