### PR TITLE
 Fix C++17 compatibility for modern compilers and log4cxx 0.12+

### DIFF
--- a/openni2_camera/CMakeLists.txt
+++ b/openni2_camera/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
+
+if(DEFINED ENV{ROS_DISTRO})
+  if($ENV{ROS_DISTRO} STREQUAL "one")
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  endif()
+endif()
+
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 project(openni2_camera)
 
 find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport  nodelet sensor_msgs roscpp message_generation)

--- a/openni2_camera/include/openni2_camera/openni2_device.h
+++ b/openni2_camera/include/openni2_camera/openni2_device.h
@@ -64,7 +64,7 @@ class OpenNI2FrameListener;
 class OpenNI2Device
 {
 public:
-  OpenNI2Device(const std::string& device_URI) throw (OpenNI2Exception);
+  OpenNI2Device(const std::string& device_URI);
   virtual ~OpenNI2Device();
 
   const std::string getUri() const;
@@ -96,12 +96,12 @@ public:
   bool isDepthStreamStarted();
 
   bool isImageRegistrationModeSupported() const;
-  void setImageRegistrationMode(bool enabled) throw (OpenNI2Exception);
-  void setDepthColorSync(bool enabled) throw (OpenNI2Exception);
+  void setImageRegistrationMode(bool enabled);
+  void setDepthColorSync(bool enabled);
 
-  const OpenNI2VideoMode getIRVideoMode() throw (OpenNI2Exception);
-  const OpenNI2VideoMode getColorVideoMode() throw (OpenNI2Exception);
-  const OpenNI2VideoMode getDepthVideoMode() throw (OpenNI2Exception);
+  const OpenNI2VideoMode getIRVideoMode();
+  const OpenNI2VideoMode getColorVideoMode();
+  const OpenNI2VideoMode getDepthVideoMode();
 
   const std::vector<OpenNI2VideoMode>& getSupportedIRVideoModes() const;
   const std::vector<OpenNI2VideoMode>& getSupportedColorVideoModes() const;
@@ -111,9 +111,9 @@ public:
   bool isColorVideoModeSupported(const OpenNI2VideoMode& video_mode) const;
   bool isDepthVideoModeSupported(const OpenNI2VideoMode& video_mode) const;
 
-  void setIRVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception);
-  void setColorVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception);
-  void setDepthVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception);
+  void setIRVideoMode(const OpenNI2VideoMode& video_mode);
+  void setColorVideoMode(const OpenNI2VideoMode& video_mode);
+  void setDepthVideoMode(const OpenNI2VideoMode& video_mode);
 
   void setIRFrameCallback(FrameCallbackFunction callback);
   void setColorFrameCallback(FrameCallbackFunction callback);
@@ -124,9 +124,9 @@ public:
   float getDepthFocalLength (int output_y_resolution) const;
   float getBaseline () const;
 
-  void setAutoExposure(bool enable) throw (OpenNI2Exception);
-  void setAutoWhiteBalance(bool enable) throw (OpenNI2Exception);
-  void setExposure(int exposure) throw (OpenNI2Exception);
+  void setAutoExposure(bool enable);
+  void setAutoWhiteBalance(bool enable);
+  void setExposure(int exposure);
 
   bool getAutoExposure() const;
   bool getAutoWhiteBalance() const;
@@ -137,9 +137,9 @@ public:
 protected:
   void shutdown();
 
-  boost::shared_ptr<openni::VideoStream> getIRVideoStream() const throw (OpenNI2Exception);
-  boost::shared_ptr<openni::VideoStream> getColorVideoStream() const throw (OpenNI2Exception);
-  boost::shared_ptr<openni::VideoStream> getDepthVideoStream() const throw (OpenNI2Exception);
+  boost::shared_ptr<openni::VideoStream> getIRVideoStream() const;
+  boost::shared_ptr<openni::VideoStream> getColorVideoStream() const;
+  boost::shared_ptr<openni::VideoStream> getDepthVideoStream() const;
 
   boost::shared_ptr<openni::Device> openni_device_;
   boost::shared_ptr<openni::DeviceInfo> device_info_;

--- a/openni2_camera/include/openni2_camera/openni2_driver.h
+++ b/openni2_camera/include/openni2_camera/openni2_driver.h
@@ -81,7 +81,7 @@ private:
   void readConfigFromParameterServer();
 
   // resolves non-URI device IDs to URIs, e.g. '#1' is resolved to the URI of the first device
-  std::string resolveDeviceURI(const std::string& device_id) throw(OpenNI2Exception);
+  std::string resolveDeviceURI(const std::string& device_id);
   void initDevice();
 
   void advertiseROSTopics();

--- a/openni2_camera/src/openni2_device.cpp
+++ b/openni2_camera/src/openni2_device.cpp
@@ -48,7 +48,7 @@
 namespace openni2_wrapper
 {
 
-OpenNI2Device::OpenNI2Device(const std::string& device_URI) throw (OpenNI2Exception) :
+OpenNI2Device::OpenNI2Device(const std::string& device_URI) :
     openni_device_(),
     ir_video_started_(false),
     color_video_started_(false),
@@ -415,7 +415,7 @@ bool OpenNI2Device::isImageRegistrationModeSupported() const
   return openni_device_->isImageRegistrationModeSupported(openni::IMAGE_REGISTRATION_DEPTH_TO_COLOR);
 }
 
-void OpenNI2Device::setImageRegistrationMode(bool enabled) throw (OpenNI2Exception)
+void OpenNI2Device::setImageRegistrationMode(bool enabled)
 {
   if (isImageRegistrationModeSupported())
   {
@@ -435,14 +435,14 @@ void OpenNI2Device::setImageRegistrationMode(bool enabled) throw (OpenNI2Excepti
   }
 }
 
-void OpenNI2Device::setDepthColorSync(bool enabled) throw (OpenNI2Exception)
+void OpenNI2Device::setDepthColorSync(bool enabled)
 {
   openni::Status rc = openni_device_->setDepthColorSyncEnabled(enabled);
   if (rc != openni::STATUS_OK)
     THROW_OPENNI_EXCEPTION("Enabling depth color synchronization failed: \n%s\n", openni::OpenNI::getExtendedError());
 }
 
-const OpenNI2VideoMode OpenNI2Device::getIRVideoMode() throw (OpenNI2Exception)
+const OpenNI2VideoMode OpenNI2Device::getIRVideoMode()
 {
   OpenNI2VideoMode ret;
 
@@ -460,7 +460,7 @@ const OpenNI2VideoMode OpenNI2Device::getIRVideoMode() throw (OpenNI2Exception)
   return ret;
 }
 
-const OpenNI2VideoMode OpenNI2Device::getColorVideoMode() throw (OpenNI2Exception)
+const OpenNI2VideoMode OpenNI2Device::getColorVideoMode()
 {
   OpenNI2VideoMode ret;
 
@@ -478,7 +478,7 @@ const OpenNI2VideoMode OpenNI2Device::getColorVideoMode() throw (OpenNI2Exceptio
   return ret;
 }
 
-const OpenNI2VideoMode OpenNI2Device::getDepthVideoMode() throw (OpenNI2Exception)
+const OpenNI2VideoMode OpenNI2Device::getDepthVideoMode()
 {
   OpenNI2VideoMode ret;
 
@@ -496,7 +496,7 @@ const OpenNI2VideoMode OpenNI2Device::getDepthVideoMode() throw (OpenNI2Exceptio
   return ret;
 }
 
-void OpenNI2Device::setIRVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception)
+void OpenNI2Device::setIRVideoMode(const OpenNI2VideoMode& video_mode)
 {
   boost::shared_ptr<openni::VideoStream> stream = getIRVideoStream();
 
@@ -509,7 +509,7 @@ void OpenNI2Device::setIRVideoMode(const OpenNI2VideoMode& video_mode) throw (Op
   }
 }
 
-void OpenNI2Device::setColorVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception)
+void OpenNI2Device::setColorVideoMode(const OpenNI2VideoMode& video_mode)
 {
   boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
 
@@ -522,7 +522,7 @@ void OpenNI2Device::setColorVideoMode(const OpenNI2VideoMode& video_mode) throw 
   }
 }
 
-void OpenNI2Device::setDepthVideoMode(const OpenNI2VideoMode& video_mode) throw (OpenNI2Exception)
+void OpenNI2Device::setDepthVideoMode(const OpenNI2VideoMode& video_mode)
 {
   boost::shared_ptr<openni::VideoStream> stream = getDepthVideoStream();
 
@@ -535,7 +535,7 @@ void OpenNI2Device::setDepthVideoMode(const OpenNI2VideoMode& video_mode) throw 
   }
 }
 
-void OpenNI2Device::setAutoExposure(bool enable) throw (OpenNI2Exception)
+void OpenNI2Device::setAutoExposure(bool enable)
 {
   boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
 
@@ -551,7 +551,7 @@ void OpenNI2Device::setAutoExposure(bool enable) throw (OpenNI2Exception)
 
   }
 }
-void OpenNI2Device::setAutoWhiteBalance(bool enable) throw (OpenNI2Exception)
+void OpenNI2Device::setAutoWhiteBalance(bool enable)
 {
   boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
 
@@ -568,7 +568,7 @@ void OpenNI2Device::setAutoWhiteBalance(bool enable) throw (OpenNI2Exception)
   }
 }
 
-void OpenNI2Device::setExposure(int exposure) throw (OpenNI2Exception)
+void OpenNI2Device::setExposure(int exposure)
 {
   boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
 
@@ -659,7 +659,7 @@ void OpenNI2Device::setDepthFrameCallback(FrameCallbackFunction callback)
   depth_frame_listener->setCallback(callback);
 }
 
-boost::shared_ptr<openni::VideoStream> OpenNI2Device::getIRVideoStream() const throw (OpenNI2Exception)
+boost::shared_ptr<openni::VideoStream> OpenNI2Device::getIRVideoStream() const
 {
   if (ir_video_stream_.get() == 0)
   {
@@ -675,7 +675,7 @@ boost::shared_ptr<openni::VideoStream> OpenNI2Device::getIRVideoStream() const t
   return ir_video_stream_;
 }
 
-boost::shared_ptr<openni::VideoStream> OpenNI2Device::getColorVideoStream() const throw (OpenNI2Exception)
+boost::shared_ptr<openni::VideoStream> OpenNI2Device::getColorVideoStream() const
 {
   if (color_video_stream_.get() == 0)
   {
@@ -691,7 +691,7 @@ boost::shared_ptr<openni::VideoStream> OpenNI2Device::getColorVideoStream() cons
   return color_video_stream_;
 }
 
-boost::shared_ptr<openni::VideoStream> OpenNI2Device::getDepthVideoStream() const throw (OpenNI2Exception)
+boost::shared_ptr<openni::VideoStream> OpenNI2Device::getDepthVideoStream() const
 {
   if (depth_video_stream_.get() == 0)
   {

--- a/openni2_camera/src/openni2_device_manager.cpp
+++ b/openni2_camera/src/openni2_device_manager.cpp
@@ -49,7 +49,7 @@ namespace openni2_wrapper
 class OpenNI2DeviceInfoComparator
 {
 public:
-  bool operator()(const OpenNI2DeviceInfo& di1, const OpenNI2DeviceInfo& di2)
+  bool operator()(const OpenNI2DeviceInfo& di1, const OpenNI2DeviceInfo& di2) const
   {
     return (di1.uri_.compare(di2.uri_) < 0);
   }

--- a/openni2_camera/src/openni2_driver.cpp
+++ b/openni2_camera/src/openni2_driver.cpp
@@ -723,7 +723,7 @@ void OpenNI2Driver::readConfigFromParameterServer()
 
 }
 
-std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id) throw(OpenNI2Exception)
+std::string OpenNI2Driver::resolveDeviceURI(const std::string& device_id)
 {
   // retrieve available device URIs, they look like this: "1d27/0601@1/5"
   // which is <vendor ID>/<product ID>@<bus number>/<device number>


### PR DESCRIPTION
## Overview
This PR fixes compilation errors when building with C++17 and log4cxx 0.12+.

## Changes

### 1. Remove dynamic exception specifications
- Dynamic exception specifications (`throw(...)`) were deprecated in C++11 and removed in C++17
- Removed all `throw(OpenNI2Exception)` declarations from headers and implementations
- Files modified:
  - `include/openni2_camera/openni2_device.h`
  - `include/openni2_camera/openni2_driver.h`
  - `src/openni2_device.cpp`
  - `src/openni2_driver.cpp`

### 2. Add const qualifier to comparison operator
- Modern C++ standard library requires comparison functors to be const-qualified
- Added `const` to `OpenNI2DeviceInfoComparator::operator()`
- Fixes compilation error: "comparison object must be invocable as const"
- File modified: `src/openni2_device_manager.cpp`

### 3. Enable C++17 for log4cxx 0.12+ compatibility
- log4cxx 0.12+ uses `std::shared_mutex`, which requires C++17
- Added conditional C++17 compilation when needed
- Also added `-DBOOST_BIND_GLOBAL_PLACEHOLDERS` to suppress Boost.Bind deprecation warnings
- File modified: `CMakeLists.txt`

## Motivation
- **log4cxx 0.12.1**  uses `std::shared_mutex`, requiring C++17
- Modern compilers enforce stricter C++ standard compliance
- These changes maintain backward compatibility with older environments

## Testing
- Built successfully with log4cxx 0.12.1
- Source code changes are backward compatible with C++14

## Backward Compatibility
- Source code modifications (removal of `throw` and adding `const`) are compatible with C++14 and earlier
- CMake changes only affect environments where C++17 is required